### PR TITLE
Remove omit query flag

### DIFF
--- a/corpus/config.go
+++ b/corpus/config.go
@@ -6,7 +6,6 @@ type Config struct {
 	Limit          int
 	NoStemming     bool
 	NoStoplist     bool
-	OmitQuery      bool
 	ShowScores     bool
 	Stoplist       *Stoplist
 	Verbose        bool

--- a/corpus/output.go
+++ b/corpus/output.go
@@ -6,7 +6,6 @@ import (
 )
 
 type score struct {
-	query    *Document
 	document *Document
 	score    float64
 }

--- a/corpus/similarity.go
+++ b/corpus/similarity.go
@@ -1,20 +1,17 @@
 package corpus
 
-import "math"
-
 func (corpus *Corpus) SimilarDocuments(query *Document) []score {
-	// Normalize query document to set TF-IDF weights per the corpus
-	query.normalizeTfIdf(corpus.invDocFreq)
+	scores := []score{}
 
-	scores := make([]score, len(corpus.documents))
-	for i, doc := range corpus.documents {
-		score := score{
-			query:    query,
-			document: doc,
-			score:    doc.cosineSimilarity(query),
+	for _, doc := range corpus.documents {
+		if doc != query {
+			score := score{
+				document: doc,
+				score:    doc.cosineSimilarity(query),
+			}
+
+			scores = append(scores, score)
 		}
-
-		scores[i] = score
 	}
 
 	return scores
@@ -27,10 +24,5 @@ func (target *Document) cosineSimilarity(other *Document) float64 {
 		dotProd += (weight * other.tfIdf[term])
 	}
 
-	sim := dotProd / (target.norm * other.norm)
-	if math.IsNaN(sim) {
-		return 0.0
-	}
-
-	return sim
+	return dotProd / (target.norm * other.norm)
 }

--- a/corpus/similarity.go
+++ b/corpus/similarity.go
@@ -1,5 +1,7 @@
 package corpus
 
+import "math"
+
 func (corpus *Corpus) SimilarDocuments(query *Document) []score {
 	// Normalize query document to set TF-IDF weights per the corpus
 	query.normalizeTfIdf(corpus.invDocFreq)
@@ -25,5 +27,10 @@ func (target *Document) cosineSimilarity(other *Document) float64 {
 		dotProd += (weight * other.tfIdf[term])
 	}
 
-	return dotProd / (target.norm * other.norm)
+	sim := dotProd / (target.norm * other.norm)
+	if math.IsNaN(sim) {
+		return 0.0
+	}
+
+	return sim
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,12 @@ func main() {
 	flag.IntVar(&config.Limit, "limit", 0, "return at most `limit` results")
 	flag.BoolVar(&config.NoStemming, "no-stemming", false, "don't perform stemming on words")
 	flag.BoolVar(&config.NoStoplist, "no-stoplist", false, "don't omit common words by using a stoplist")
-	flag.BoolVar(&config.OmitQuery, "omit-query", false, "don't include the query file itself in search results")
+
+	// This is being kept as a flag (as of v0.1.5) for backward compatibility with
+	// docsim.el, but the functionality's been removed; regardless of the flag, we
+	// never include the query in search results.
+	flag.Bool("omit-query", true, "[deprecated] don't include the query file itself in search results")
+
 	flag.BoolVar(&config.ShowScores, "show-scores", false, "print scores next to file paths")
 	flag.BoolVar(&config.Verbose, "verbose", false, "include debugging information and errors")
 	stdinFlag := flag.Bool("stdin", false, "read query from STDIN instead of from a positional string arugment")

--- a/man/docsim.1
+++ b/man/docsim.1
@@ -88,14 +88,6 @@ disabled when searching across code or documents in other languages.
 .BR \-\-no\-stoplist
 Don't filter out common words, like "the" and "because".
 .TP
-.BR \-\-omit\-query
-Don't include the query document itself in the results, even if it's in a
-directory being searched.
-.PP
-.RS
-This has no effect unless used with the \fB\-\-file\fR flag.
-.RE
-.TP
 .BR \-\-show\-scores
 Include the cosine similarity between each document and the query in the results.
 .TP


### PR DESCRIPTION
The query's always going to be 100% similar to itself, so returning it conveys no useful information, and maintaining this flag complicates tracking scores and displaying results.

This commit also ensures that the query itself (whether from a positional arg, `STDIN`, or a `--file` argument) will be parsed and included in the corpus. That should marginally improve accuracy and also lets us remove the fussy test for whether the cosine similarity was NaN.