### PR TITLE
Fix lintian errors for `deb` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 docsim
+manpages/*.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,9 @@
 project_name: docsim
 
+before:
+  hooks:
+    - sh -c "gzip -c -n -9 ./manpages/docsim.1 > ./manpages/docsim.1.gz"
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -36,7 +40,7 @@ brews:
       branch: main
       token: "{{ .Env.GITHUB_TOKEN }}"
     goarm: "7"
-    description: A local, in-memory search tool, ranking results by textual similarity.
+    description: Local, in-memory search tool, ranking results by textual similarity.
     homepage: https://github.com/hrs/docsim
     license: GPL-3.0-or-later
     test: system "make test"
@@ -46,20 +50,28 @@ brews:
 
 nfpms:
   - maintainer: Harry R. Schwartz <hello@harryrschwartz.com>
-    description: A local, in-memory search tool, ranking results by textual similarity.
+    description: |-
+      Local, in-memory search tool, ranking results by textual similarity.
+      Docsim uses information retrieval techniques (like stemming and TF-IDF) to
+      parse text documents and rank them by similarity to a given query. It's
+      like a local search engine for your notes or code.
     bindir: /usr/bin
     section: utils
     homepage: https://github.com/hrs/docsim
     license: GPLv3
     contents:
-      - src: ./manpages/docsim.1
-        dst: /usr/share/man/man1/docsim.1
+      - src: ./manpages/docsim.1.gz
+        dst: /usr/share/man/man1/docsim.1.gz
         file_info:
           mode: 0644
-      - src: ./LICENSE.md
+      - src: ./debian/copyright
         dst: /usr/share/doc/docsim/copyright
         file_info:
           mode: 0644
     formats:
       - deb
       - rpm
+    deb:
+      lintian_overrides:
+        - statically-linked-binary
+        - changelog-file-missing-in-native-package

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,7 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: *
+Copyright: © 2023 Harry R. Schwartz <hello@harryschwartz.com> and contributors
+License: GPL-3+
+ The full text of the GPL is distributed as ./LICENSE.md in docsim's source,
+ and is distributed in /usr/share/common-licenses/GPL-3 on Debian systems.


### PR DESCRIPTION
[`lintian`](https://lintian.debian.org/) is a tool for linting Debian packages to ensure they comply with Debian's standards. Now that we're releasing .deb packages for docsim we might as well do it correctly!

- don't start package description with an article
- don't include the full text of the GPL3 (link to it instead)
- override prohibition on static linking (Go statically links binaries and lintian's detection system doesn't seem to make an exception, so we have to override that)
- gzip the manpage
- include an extended package description

For future reference, to build the package locally and ensure it complies:

    $ goreleaser release --snapshot --skip-publish --clean && lintian dist/docsim_*amd64.deb