### PR TITLE
Ensure stemming doesn't panic on certain inputs

### DIFF
--- a/corpus/stem.go
+++ b/corpus/stem.go
@@ -1,6 +1,6 @@
 package corpus
 
-import "github.com/reiver/go-porterstemmer"
+import "github.com/blevesearch/go-porterstemmer"
 
 var stemCache = make(map[string]string)
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/hrs/docsim
 
 go 1.19
 
-require github.com/reiver/go-porterstemmer v1.0.1
+require github.com/blevesearch/go-porterstemmer v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/reiver/go-porterstemmer v1.0.1 h1:WyERBkASXgoXrTwq/IQ6wyNj/YG7j/ZURvTuMCoud5w=
-github.com/reiver/go-porterstemmer v1.0.1/go.mod h1:Z8uL/f/7UEwaeAJNwx1sO8kbqXiEuQieNuD735hLrSU=
+github.com/blevesearch/go-porterstemmer v1.0.3 h1:GtmsqID0aZdCSNiY8SkuPJ12pD4jI+DdXTAn4YRcHCo=
+github.com/blevesearch/go-porterstemmer v1.0.3/go.mod h1:angGc5Ht+k2xhJdZi511LtmxuEf0OVpvUUNrwmM1P7M=


### PR DESCRIPTION
Certain odd terms (like "eed") that occasionally appear in code caused the implementation of the Porter stemming algorithm we'd been using to panic.

The maintainer seems to be AWOL, but someone seems to have forked the original repo and applied some changes, including fixing that bug.

- old: https://github.com/reiver/go-porterstemmer
- new: https://github.com/blevesearch/go-porterstemmer

This migrates us over to the new version, which has the same interface.