### PR TITLE
Update Go 1.19 → 1.20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Go 1.19
+      - name: Install Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
         id: go
 
       - name: Run tests

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/hrs/docsim
 
-go 1.19
+go 1.20
 
 require github.com/blevesearch/go-porterstemmer v1.0.3


### PR DESCRIPTION
With 1.21 RCs coming out, it'd be nice to not be two versions behind. :-)